### PR TITLE
Use HTTP POST method for logging URL

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
@@ -83,7 +83,7 @@ public class CustomUrlJob extends Job {
             conn = (HttpURLConnection) url.openConnection();
         }
 
-        conn.setRequestMethod("GET");
+        conn.setRequestMethod("POST");
 
         if(!Utilities.IsNullOrEmpty(basicPassword) && !Utilities.IsNullOrEmpty(basicUsername) ){
             String basicAuth = "Basic " + new String(Base64.encode((basicUsername + ":" + basicPassword).getBytes(), Base64.DEFAULT));


### PR DESCRIPTION
Logged data is sent via HTTP GET method currently. According to the HTTP specification the GET method should not modify remote entity, but read it's actual state.
To be more compliant with HTTP standards this commit swaps the method to POST.